### PR TITLE
Disabled shading-in jansi

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
         <maven.compiler.source>1.5</maven.compiler.source>
         <maven.compiler.target>1.5</maven.compiler.target>
 
-        <jansi.version>1.12</jansi.version>
+        <jansi.version>1.16</jansi.version>
     </properties>
 
     <prerequisites>
@@ -364,8 +364,7 @@
                         <configuration>
                             <instructions>
                                 <Export-Package>
-                                    jline.*;-noimport:=true,
-                                    =org.fusesource.jansi;version=${jansi.version}
+                                    jline.*;-noimport:=true
                                 </Export-Package>
                                 <Import-Package>
                                     !javax.swing
@@ -398,43 +397,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-scm-plugin</artifactId>
                 <version>1.9.4</version>
-            </plugin>
-
-            <!-- include all the dependencies into the jar so it can run standalone -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>2.4.1</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                        <configuration>
-                            <artifactSet>
-                                <excludes>
-                                    <exclude>junit:junit</exclude>
-                                </excludes>
-                            </artifactSet>
-                            <filters>
-                                <filter>
-                                    <artifact>org.fusesource.jansi:jansi</artifact>
-                                    <excludes>
-                                        <exclude>META-INF/maven/**</exclude>
-                                        <exclude>*.txt</exclude>
-                                        <exclude>junit/**</exclude>
-                                        <exclude>org/junit/**</exclude>
-                                        <exclude>org/hamcrest/**</exclude>
-                                        <exclude>org/fusesource/hawtjni/runtime/Jni*</exclude>
-                                        <exclude>org/fusesource/hawtjni/runtime/*Flag*</exclude>
-                                        <exclude>org/fusesource/hawtjni/runtime/T32*</exclude>
-                                        <exclude>org/fusesource/hawtjni/runtime/NativeStats*</exclude>
-                                    </excludes>
-                                </filter>
-                            </filters>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
 
             <plugin>


### PR DESCRIPTION
Shading in the jansi dependency inside jline2 jar instead of using ordinary dependency crates classpath issues down the line.